### PR TITLE
modified agent and weapon model, fixed the 6 tests so that they connect to the new database

### DIFF
--- a/server/models/submodel/Agent.js
+++ b/server/models/submodel/Agent.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 
 // Define the Agent model in MongoDB
 const AgentSchema = new mongoose.Schema({
-  agentName: {
+  name: {
     type: String,
     required: true, // every agent must have a name
     unique: true    // no two agents can share the same name
@@ -33,14 +33,14 @@ const AgentSchema = new mongoose.Schema({
       description: { type: String }     // description of what the ability does
     }
   ],
-  difficulty: {     // optional - used to describe how difficult the agent is to play/learn 
-    type: String    // Ex. easy, medium, hard
+  difficulty: {     // used to describe how difficult the agent is to play/learn 
+    type: String, 
+    enum: ['Easy', 'Medium', 'Hard']   
   },
-  imageUrl: {
-    type: String    // optional - for displaying image of agent in the archive
+  imageURL: {
+    type: String    // for displaying image of agent in the archive
   }
 });
 
 // Export model so that other files can use it
 module.exports = mongoose.model('Agent', AgentSchema);
-

--- a/server/models/submodel/Weapon.js
+++ b/server/models/submodel/Weapon.js
@@ -2,18 +2,33 @@ const mongoose = require('mongoose');
 
 // Define the Weapon model in MongoDB
 const WeaponSchema = new mongoose.Schema({
-  weaponName: {
+  name: {
     type: String,
     required: true, // every weapon must have a name
     unique: true    // no two weapons can share the same name
   },
-  weaponType: {     // Ex. sidearm, SMG, shotgun, rifle 
+  type: {           // Ex. sidearm, SMG, shotgun, rifle 
     type: String,
     required: true  // every weapon must have a type
   },
   description: {
     type: String,
     required: true  // every weapon must have a description for the archive
+  },
+  fireMode: {       // Ex. automatic, semi-automatic, burst
+    type: String,
+  },
+  rateOfFire: {     // rounds per second
+    type: Number,
+    min: 0
+  },
+  magazineCapacity: { // number of rounds per magazine
+    type: Number,
+    min: 0
+  },
+  wallPenetration: { // how well the weapon penetrates surfaces
+    type: String,
+    enum: ['Low', 'Medium', 'High']
   },
   advantages: [     // is an array since each weapon can have multiple advantages
     { 
@@ -28,7 +43,7 @@ const WeaponSchema = new mongoose.Schema({
     }
   ],
   imageUrl: {
-    type: String    // optional - for displaying image of weapon in the archive
+    type: String    // for displaying image of weapon in the archive
   }
 });
 

--- a/server/tests/AgentModel.test.js
+++ b/server/tests/AgentModel.test.js
@@ -1,13 +1,22 @@
+// Load environment variables from .env file for MongoDB connection
+require('dotenv').config({ path: './.env' })
+
+// Use Google's DNS to resolve MongoDB SRV records on Windows
+const dns = require('dns');
+dns.setServers(['8.8.8.8', '8.8.4.4']); 
+
+// Import Mongoose library
 const mongoose = require("mongoose")
 
+// Import Agent model
 const Agent = require("../models/submodel/Agent")
 
 describe("Agent Model Test", () => {
 
-  // Connect to MongoDB before running tests
+  // Connect to MongoDB Atlas before running tests
   beforeAll(async () => {
-    await mongoose.connect("mongodb://localhost:27017/agent-test");
-  })
+  await mongoose.connect(process.env.MONGODB_URI  + "-test");
+}, 10000)
 
   // Close connection after tests
   afterAll(async () => {
@@ -17,12 +26,13 @@ describe("Agent Model Test", () => {
   // Clear the database before each test
   beforeEach(async () => {
     await Agent.deleteMany({})
+    await Agent.syncIndexes()
   })
 
   // Test that a valid agent saves successfully
   test("should create & save agent successfully", async () => {
     const validAgent = new Agent({
-      agentName: "Phoenix",
+      name: "Phoenix",
       role: "Duelist",
       description: "Phoenix is an aggressive duelist who specializes in self-sustain and entry fragging. His kit revolves around fire-based abilities that can suppress enemies and heal himself.",
       advantages: 
@@ -53,14 +63,14 @@ describe("Agent Model Test", () => {
 
     // Verify the agent was saved with the correct values
     expect(savedAgent._id).toBeDefined()
-    expect(savedAgent.agentName).toBe("Phoenix")
+    expect(savedAgent.name).toBe("Phoenix")
     expect(savedAgent.role).toBe("Duelist")
     expect(savedAgent.abilities).toHaveLength(4)
   })
 
   // Test that required fields are enforced
   test("should fail if required fields are missing", async () => {
-    const invalidAgent = new Agent({ agentName: "Phoenix" }) // missing role and description
+    const invalidAgent = new Agent({ name: "Phoenix" }) // missing role and description
     let err
     try {
       await invalidAgent.save()
@@ -73,16 +83,16 @@ describe("Agent Model Test", () => {
   })
 
   // Test that two agents cannot share the same name
-  test("should fail if agentName is not unique", async () => {
+  test("should fail if name is not unique", async () => {
     const firstAgent = new Agent({
-      agentName: "Phoenix",
+      name: "Phoenix",
       role: "Duelist",
       description: "A fire-based duelist"
     })
     await firstAgent.save()
 
     const duplicateAgent = new Agent({
-      agentName: "Phoenix", // same name, should fail
+      name: "Phoenix", // same name, should fail
       role: "Controller",
       description: "A different agent"
     })

--- a/server/tests/CoachModel.test.js
+++ b/server/tests/CoachModel.test.js
@@ -1,24 +1,34 @@
+// Load environment variables from .env file for MongoDB connection
+require('dotenv').config({ path: './.env' })
+
+// Use Google's DNS to resolve MongoDB SRV records on Windows
+const dns = require('dns');
+dns.setServers(['8.8.8.8', '8.8.4.4']); 
+
+// Import Mongoose library
 const mongoose = require("mongoose");
+
+// Import User, Coach, and Team models
 const User = require("../models/User");
 const Coach = require("../models/Coach");
 const Team = require("../models/Team");
 
 describe("Coach Model Test", () => {
 
-  // Connect to a test database
-  beforeAll(async () => {
-    await mongoose.connect("mongodb://localhost:27017/coach-test", {});
-  });
+  // Connect to MongoDB Atlas before running tests
+    beforeAll(async () => {
+    await mongoose.connect(process.env.MONGODB_URI + "-test");
+  }, 10000)
 
   // Clear the collections before each test
   beforeEach(async () => {
     await User.deleteMany({});
     await Team.deleteMany({});
+    await Coach.syncIndexes();
   });
 
   // Disconnect after tests
   afterAll(async () => {
-    await mongoose.connection.dropDatabase();
     await mongoose.connection.close();
   });
 

--- a/server/tests/MapModel.test.js
+++ b/server/tests/MapModel.test.js
@@ -1,14 +1,23 @@
+// Load environment variables from .env file for MongoDB connection
+require('dotenv').config({ path: './.env' })
+
+// Use Google's DNS to resolve MongoDB SRV records on Windows
+const dns = require('dns');
+dns.setServers(['8.8.8.8', '8.8.4.4']); 
+
+// Import Mongoose library
 const mongoose = require("mongoose")
 
-const Map = require("../models/Map");
+// Import Map model
+const Map = require("../models/submodel/Map");
 
 describe("Map Model Test", () => {
 
-    // Connect to a new mongoose server for test
+    // Connect to MongoDB Atlas before running tests
     beforeAll(async () => {
-        await mongoose.connect("mongodb://localhost:27017/map-test");
-    })
-
+       await mongoose.connect(process.env.MONGODB_URI  + "-test");
+    }, 10000)
+   
     // Close connection after tests
     afterAll(async () => {
         await mongoose.connection.close()
@@ -17,6 +26,7 @@ describe("Map Model Test", () => {
     // Clear database before each test
     beforeEach(async () => {
         await Map.deleteMany({})
+        await Map.syncIndexes();
     })
 
     // Test that a valid map saves successfully

--- a/server/tests/PlayerModel.test.js
+++ b/server/tests/PlayerModel.test.js
@@ -1,19 +1,31 @@
+// Load environment variables from .env file for MongoDB connection
+require('dotenv').config({ path: './.env' })
+
+// Use Google's DNS to resolve MongoDB SRV records on Windows
+const dns = require('dns');
+dns.setServers(['8.8.8.8', '8.8.4.4']); 
+
+// Import Mongoose library
 const mongoose = require("mongoose");
+
+// Import User and Player models
 const User = require("../models/User");
 const Player = require("../models/Player");
 
 describe("Player Model Test", () => {
 
+    // Connect to MongoDB Atlas before running tests
     beforeAll(async () => {
-        await mongoose.connect("mongodb://127.0.0.1:27017/player-test");
-    });
+       await mongoose.connect(process.env.MONGODB_URI  + "-test");
+    }, 10000)
 
     beforeEach(async () => {
-        await User.deleteMany({});
+        await User.deleteMany({})
+        await Player.deleteMany({})
+        await Player.syncIndexes();
     });
 
     afterAll(async () => {
-        await mongoose.connection.dropDatabase();
         await mongoose.connection.close();
     });
 

--- a/server/tests/UserModel.test.js
+++ b/server/tests/UserModel.test.js
@@ -1,12 +1,22 @@
+// Load environment variables from .env file for MongoDB connection
+require('dotenv').config({ path: './.env' })
+
+// Use Google's DNS to resolve MongoDB SRV records on Windows
+const dns = require('dns');
+dns.setServers(['8.8.8.8', '8.8.4.4']); 
+
+// Import Mongoose library
 const mongoose = require("mongoose")
+
+// Import User model
 const User = require("../models/User")
 
 describe("User Model Test", () => {
 
-  // Connect to MongoDB before running tests
-  beforeAll(async () => {
-    await mongoose.connect("mongodb://localhost:27017/user-test");
-  })
+  // Connect to MongoDB Atlas before running tests
+    beforeAll(async () => {
+    await mongoose.connect(process.env.MONGODB_URI  + "-test");
+  }, 10000)
 
   // Close connection after tests
   afterAll(async () => {
@@ -16,6 +26,7 @@ describe("User Model Test", () => {
   // Clear the database before each test
   beforeEach(async () => {
     await User.deleteMany({})
+    await User.syncIndexes()
   })
 
   // Test case for creating a user successfully
@@ -45,4 +56,29 @@ describe("User Model Test", () => {
     expect(err.errors.password).toBeDefined()
   })
 
+  // Test case for unique username and email
+  test("should fail if username or email is not unique", async () => {
+  const firstUser = new User({
+    username: "testuser",
+    email: "test@email.com",
+    password: "hashedpassword"
+  })
+  await firstUser.save()
+
+  const duplicateUser = new User({
+    username: "testuser", // duplicate username
+    email: "test@email.com", // duplicate email
+    password: "differentpassword"
+  })
+
+  let err
+  try {
+    await duplicateUser.save()
+  } catch (error) {
+    err = error
+  }
+
+  expect(err).toBeDefined()
+  expect(err.code).toBe(11000) // MongoDB duplicate key error
+  })
 })

--- a/server/tests/WeaponModel.test.js
+++ b/server/tests/WeaponModel.test.js
@@ -1,3 +1,10 @@
+// Load environment variables from .env file for MongoDB connection
+require('dotenv').config({ path: './.env' })
+
+// Use Google's DNS to resolve MongoDB SRV records on Windows
+const dns = require('dns');
+dns.setServers(['8.8.8.8', '8.8.4.4']); 
+
 // Import Mongoose library
 const mongoose = require("mongoose")
 
@@ -6,10 +13,10 @@ const Weapon = require("../models/submodel/Weapon")
 
 describe("Weapon Model Test", () => {
 
-  // Connect to MongoDB before running tests
+  // Connect to MongoDB Atlas before running tests
   beforeAll(async () => {
-    await mongoose.connect("mongodb://localhost:27017/weapon-test");
-  })
+    await mongoose.connect(process.env.MONGODB_URI  + "-test");
+  }, 10000)
 
   // Close connection after tests
   afterAll(async () => {
@@ -25,9 +32,13 @@ describe("Weapon Model Test", () => {
   // Test that a valid weapon saves successfully
   test("should create & save weapon successfully", async () => {
     const validWeapon = new Weapon({
-      weaponName: "Vandal",
-      weaponType: "Rifle",
+      name: "Vandal",
+      type: "Rifle",
       description: "The Vandal is a fully automatic rifle that deals consistent damage at any range. It is one of the most popular weapons in the game due to its high damage output and versatility.",
+      fireMode: "Automatic",
+      rateOfFire: 9.75,
+      magazineCapacity: 25,
+      wallPenetration: "Medium",
       advantages: [
         { title: "One shot headshot", explanation: "Can kill an enemy with a single headshot at any range." },
         { title: "Consistent damage", explanation: "Unlike some rifles, its damage does not fall off at longer ranges." },
@@ -44,15 +55,19 @@ describe("Weapon Model Test", () => {
 
     // Verify the weapon was saved with the correct values
     expect(savedWeapon._id).toBeDefined()
-    expect(savedWeapon.weaponName).toBe("Vandal")
-    expect(savedWeapon.weaponType).toBe("Rifle")
+    expect(savedWeapon.name).toBe("Vandal")
+    expect(savedWeapon.type).toBe("Rifle")
+    expect(savedWeapon.fireMode).toBe("Automatic")
+    expect(savedWeapon.rateOfFire).toBe(9.75)
+    expect(savedWeapon.magazineCapacity).toBe(25)
+    expect(savedWeapon.wallPenetration).toBe("Medium")
     expect(savedWeapon.advantages).toHaveLength(3)
     expect(savedWeapon.disadvantages).toHaveLength(3)
   })
 
   // Test that required fields are enforced
   test("should fail if required fields are missing", async () => {
-    const invalidWeapon = new Weapon({ weaponName: "Vandal" }) // missing weaponType and description
+    const invalidWeapon = new Weapon({ name: "Vandal" }) // missing type and description
     let err
     try {
       await invalidWeapon.save()
@@ -60,22 +75,22 @@ describe("Weapon Model Test", () => {
       err = error
     }
     expect(err).toBeInstanceOf(mongoose.Error.ValidationError)
-    expect(err.errors.weaponType).toBeDefined()    // weaponType was missing
+    expect(err.errors.type).toBeDefined()          // type was missing
     expect(err.errors.description).toBeDefined()   // description was missing
   })
 
   // Test that two weapons cannot share the same name
-  test("should fail if weaponName is not unique", async () => {
+  test("should fail if name is not unique", async () => {
     const firstWeapon = new Weapon({
-      weaponName: "Vandal",
-      weaponType: "Rifle",
+      name: "Vandal",
+      type: "Rifle",
       description: "A fully automatic rifle."
     })
     await firstWeapon.save()
 
     const duplicateWeapon = new Weapon({
-      weaponName: "Vandal", // same name, should fail
-      weaponType: "SMG",
+      name: "Vandal", // same name, should fail
+      type: "SMG",
       description: "A different weapon."
     })
     let err
@@ -84,24 +99,63 @@ describe("Weapon Model Test", () => {
     } catch (error) {
       err = error
     }
-    expect(err).toBeDefined() // should have thrown an error
+    expect(err).toBeDefined()
   })
 
   // Test that optional fields can be omitted without error
   test("should save successfully without optional fields", async () => {
     const weaponWithoutOptionals = new Weapon({
-      weaponName: "Classic",
-      weaponType: "Sidearm",
+      name: "Classic",
+      type: "Sidearm",
       description: "A reliable sidearm available to all players for free at the start of each round."
-      // no advantages, disadvantages, or imageUrl
+      // no fireMode, rateOfFire, magazineCapacity, wallPenetration, advantages, disadvantages, or imageUrl
     })
     const savedWeapon = await weaponWithoutOptionals.save()
 
-    // Verify it saved fine without the optional fields
     expect(savedWeapon._id).toBeDefined()
-    expect(savedWeapon.advantages).toHaveLength(0)      // empty array by default
-    expect(savedWeapon.disadvantages).toHaveLength(0)   // empty array by default
-    expect(savedWeapon.imageUrl).toBeUndefined()        // not provided
+    expect(savedWeapon.fireMode).toBeUndefined()
+    expect(savedWeapon.rateOfFire).toBeUndefined()
+    expect(savedWeapon.magazineCapacity).toBeUndefined()
+    expect(savedWeapon.wallPenetration).toBeUndefined()
+    expect(savedWeapon.advantages).toHaveLength(0)
+    expect(savedWeapon.disadvantages).toHaveLength(0)
+    expect(savedWeapon.imageUrl).toBeUndefined()
   })
 
+  // Test that wallPenetration enum is enforced
+  test("should fail if wallPenetration is not a valid enum value", async () => {
+    const invalidWeapon = new Weapon({
+      name: "Phantom",
+      type: "Rifle",
+      description: "A fully automatic rifle.",
+      wallPenetration: "Ultra" // not a valid enum value
+    })
+    let err
+    try {
+      await invalidWeapon.save()
+    } catch (error) {
+      err = error
+    }
+    expect(err).toBeInstanceOf(mongoose.Error.ValidationError)
+    expect(err.errors.wallPenetration).toBeDefined()
+  })
+
+  test("should fail if rateOfFire or magazineCapacity is negative", async () => {
+  const invalidWeapon = new Weapon({
+    name: "Phantom",
+    type: "Rifle",
+    description: "A fully automatic rifle.",
+    rateOfFire: -5,       // invalid
+    magazineCapacity: -10 // invalid
+  })
+  let err
+  try {
+    await invalidWeapon.save()
+  } catch (error) {
+    err = error
+  }
+  expect(err).toBeInstanceOf(mongoose.Error.ValidationError)
+  expect(err.errors.rateOfFire).toBeDefined()
+  expect(err.errors.magazineCapacity).toBeDefined()
+  })
 })


### PR DESCRIPTION
Changed the agent schema:
- agentName -> name (to follow shahd's naming convention so that when accessing attributes it is agent.name instead of agent.agentName)
- added enum array to difficulty attribute

Changed the weapon schema:
- weaponName -> name
- weaponType -> type
- added 4 attributes: fireMode, rateOfFire, magazineCapacity, and wallPenetration

Changed all 6 tests in the tests folder so that they work with MongoDB atlas instead of a local MongoDB:
- uses a test database that is dynamically created and deleted, so it won't affect the real database (comes from a modified URI string)
- added a test to UserModel.test to check for unique username and email
- added a test to WeaponModel.test to check that enum is enforced and rateOfFire and magazineCapacity cannot be negative

Note: these modifications were moved from the branch tai/modify-agent-and-weapon-models
- some of the tests still fail, i can't seem to figure out why though